### PR TITLE
MAE-508: Fix invalid price field id

### DIFF
--- a/lineitemedit.php
+++ b/lineitemedit.php
@@ -268,7 +268,7 @@ function lineitemedit_civicrm_pre($op, $entity, $entityID, &$params) {
           $lineItem['qty']
         );
 
-        $newLineItemParams = array(
+        $newLineItemParams[] = array(
           'entity_table' => $lineEntityTable,
           'entity_id' => $lineEntityID,
           'contribution_id' => $entityID,
@@ -281,7 +281,10 @@ function lineitemedit_civicrm_pre($op, $entity, $entityID, &$params) {
           'financial_type_id' => $lineItem['financial_type_id'],
           'tax_amount' => CRM_Utils_Array::value('tax_amount', $lineItem),
         );
-        $newLineItem[] = civicrm_api3('LineItem', 'create', $newLineItemParams)['id'];
+      }
+
+      foreach ($newLineItemParams as $lineItem) {
+        $newLineItem[] = civicrm_api3('LineItem', 'create', $lineItem)['id'];
       }
 
       if (!empty($lineItemParams)) {


### PR DESCRIPTION
## Overview
This PR fixed the issue when adding more than one line items at a time.

## Before
![Peek 2021-03-29 15-34](https://user-images.githubusercontent.com/74309109/112837523-ab6cc280-90a4-11eb-9880-871e7139eeea.gif)


## After
![Peek 2021-03-29 15-37](https://user-images.githubusercontent.com/74309109/112837540-b0ca0d00-90a4-11eb-8257-4a80d849cf22.gif)


## Technical Details
This extension will create price field for each line item inside the `foreach` loop.
```php
foreach ($lineItemParams as $key => $lineItem) {
  if ($lineItem['price_field_value_id'] == 'new') {
    list($lineItem['price_field_id'], $lineItem['price_field_value_id']) = CRM_Lineitemedit_Util::createPriceFieldByContributionID($entityID);
  }
      
  ...
  $newLineItem[] = civicrm_api3('LineItem', 'create', $newLineItemParams)['id'];
}
```
When creating the line item CiviCRM internally will validate each price field and one of the validation steps is fetching the potential values/options to check against - see [utils.php#L2276](https://github.com/civicrm/civicrm-core/blob/5.35.1/api/v3/utils.php#L2276). 

```php
$options = civicrm_api($entity, 'getoptions', $options_lookup_params);
```

CiviCRM will cache `getoptions` result in [PseudoConstant.php#L278](https://github.com/civicrm/civicrm-core/blob/5.35.1/CRM/Core/PseudoConstant.php#L278)
```php
\Civi::$statics[__CLASS__][$cacheKey] = $output;
```

Everything is fine for one line item creating but when we create two items or more in one go, the price fields ids was cached in the first iteration during the creating of the first line item and CiviCRM will throw error when creating the second line item because the price field is invalid.

To overcome this issue, I moved the creation of line items outside of the `foreach` loop. That way the main `foreach` loop will prepare the params and create the required price fields and then will create the line items.